### PR TITLE
Rework GUI testing setup

### DIFF
--- a/Dockerfile.novnc
+++ b/Dockerfile.novnc
@@ -1,0 +1,8 @@
+FROM buildpack-deps:jessie-curl as downloader
+
+RUN mkdir -p /usr/share/novnc
+RUN wget --quiet -O- "https://github.com/novnc/noVNC/tarball/master" | tar -xvzf - --strip-components=1 -C /usr/share/novnc
+
+FROM alpine
+COPY --from=downloader /usr/share/novnc /usr/share/novnc
+CMD ["/bin/true"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -9,12 +9,7 @@ RUN raco pkg install --auto --installation --skip-installed \
     main-distribution-test \
     raco-find-collection \
     https://github.com/racket/pcps-test.git
-RUN apt-get update
-RUN apt-get install -y xvfb
-RUN apt-get install -y libgtk2.0-0
 
 COPY ./test.sh /usr/bin/racket-tests.sh
 RUN chmod +x /usr/bin/racket-tests.sh
-COPY ./test-gui.sh /usr/bin/racket-gui-tests.sh
-RUN chmod +x /usr/bin/racket-gui-tests.sh
-CMD ["/bin/sh", "-c", "/usr/bin/racket-tests.sh" -c "/usr/bin/racket-gui-tests.sh"]
+CMD ["/bin/sh", "-c", "/usr/bin/racket-tests.sh"]

--- a/Dockerfile.test-gui
+++ b/Dockerfile.test-gui
@@ -1,0 +1,11 @@
+ARG RACKET_TEST_IMAGE
+
+FROM ${RACKET_TEST_IMAGE}
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgtk2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY ./test-gui.sh /usr/bin/racket-gui-tests.sh
+RUN chmod +x /usr/bin/racket-gui-tests.sh
+CMD ["/bin/sh", "-c", "/usr/bin/racket-gui-tests.sh"]

--- a/Dockerfile.x11vnc
+++ b/Dockerfile.x11vnc
@@ -1,0 +1,8 @@
+FROM alpine:edge
+RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ x11vnc
+
+# Default port is 5900 plus display number, but docker expects static port
+# numbers so we always use 5900 regardless of what display we're talking to
+EXPOSE 5900
+ENTRYPOINT ["/usr/bin/x11vnc"]
+CMD ["-rfbport", "5900", "-shared", "-viewonly", "-forever", "-nopw"]

--- a/Dockerfile.xvfb
+++ b/Dockerfile.xvfb
@@ -1,0 +1,8 @@
+FROM alpine
+RUN apk add --no-cache xvfb
+
+# X server TCP port number is 6000 plus display number, which CMD sets to zero
+EXPOSE 6000
+
+ENTRYPOINT ["/usr/bin/Xvfb"]
+CMD [":0", "-ac", "-listen", "tcp", "-noreset"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,38 @@ services:
       DISPLAY: xvfb:0.0
     depends_on:
       - xvfb
+  websockify:
+    # TODO: This image was chosen via a lazy google search and may break at any
+    # time without warning.
+    image: efrecon/websockify
+    command: 50000 x11vnc:5900
+    ports:
+      - "50000:50000"
+    depends_on:
+      - x11vnc
+  novnc:
+    build:
+      context: .
+      dockerfile: Dockerfile.novnc
+    volumes:
+      - nginx-html:/usr/share/novnc
+  nginx:
+    image: nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./novnc-proxy.conf:/etc/nginx/conf.d/default.conf:ro
+      # The nocopy option is needed to ensure that novnc's preexisting files
+      # are copied into the nginx-html volume, then copied from the nginx-html
+      # volume into the nginx contaier itself. Without nocopy, nginx's files in
+      # the /usr/share/nginx/html directory could get copied into the volume
+      # instead of the other way around. Technically the read-only option and
+      # the dependency on novnc (ensuring novnc uses the volume first) should
+      # prevent that from happening, but that's a little too magic to rely on.
+      - nginx-html:/usr/share/nginx/html:ro,nocopy
+    depends_on:
+      - novnc
+      - websockify
 
   racket-x86:
     image: racket-x86
@@ -199,3 +231,6 @@ services:
   #     dockerfile: Dockerfile.test
   #     args:
   #       RACKET_IMAGE: racket-x86-natipkg-minimal
+
+volumes:
+  nginx-html:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,11 @@ services:
   # TODO: Both installer downloads and package downloads could conceivably be
   # cached. Should wait until after test runner container is implemented.
 
+  xvfb:
+    build:
+      context: .
+      dockerfile: Dockerfile.xvfb
+
   racket-x86:
     image: racket-x86
     build:
@@ -39,11 +44,22 @@ services:
         RACKET_INSTALLER_DIST: racket
     command: racket -e '(+ 1 2)'
   racket-x86-test:
+    image: racket-x86-test
     build:
       context: .
       dockerfile: Dockerfile.test
       args:
         RACKET_IMAGE: racket-x86
+  racket-x86-test-gui:
+    build:
+      context: .
+      dockerfile: Dockerfile.test-gui
+      args:
+        RACKET_TEST_IMAGE: racket-x86-test
+    environment:
+      DISPLAY: xvfb:0.0
+    depends_on:
+      - xvfb
 
   racket-x86-minimal:
     image: racket-x86-minimal
@@ -56,11 +72,22 @@ services:
         RACKET_INSTALLER_DIST: racket-minimal
     command: racket -e '(+ 1 2)'
   racket-x86-minimal-test:
+    image: racket-x86-minimal-test
     build:
       context: .
       dockerfile: Dockerfile.test
       args:
         RACKET_IMAGE: racket-x86-minimal
+  racket-x86-minimal-test-gui:
+    build:
+      context: .
+      dockerfile: Dockerfile.test-gui
+      args:
+        RACKET_TEST_IMAGE: racket-x86-minimal-test
+    environment:
+      DISPLAY: xvfb:0.0
+    depends_on:
+      - xvfb
 
   racket-i386:
     image: racket-i386
@@ -77,11 +104,22 @@ services:
         RACKET_INSTALLER_DIST: racket
     command: racket -e '(+ 1 2)'
   racket-i386-test:
+    image: racket-i386-test
     build:
       context: .
       dockerfile: Dockerfile.test
       args:
         RACKET_IMAGE: racket-i386
+  racket-i386-test-gui:
+    build:
+      context: .
+      dockerfile: Dockerfile.test-gui
+      args:
+        RACKET_TEST_IMAGE: racket-i386-test
+    environment:
+      DISPLAY: xvfb:0.0
+    depends_on:
+      - xvfb
 
   racket-i386-minimal:
     image: racket-i386-minimal
@@ -96,11 +134,22 @@ services:
         RACKET_INSTALLER_DIST: racket-minimal
     command: racket -e '(+ 1 2)'
   racket-i386-minimal-test:
+    image: racket-i386-minimal-test
     build:
       context: .
       dockerfile: Dockerfile.test
       args:
         RACKET_IMAGE: racket-i386-minimal
+  racket-i386-minimal-test-gui:
+    build:
+      context: .
+      dockerfile: Dockerfile.test-gui
+      args:
+        RACKET_TEST_IMAGE: racket-i386-minimal-test
+    environment:
+      DISPLAY: xvfb:0.0
+    depends_on:
+      - xvfb
 
   # TODO: Figure out why natipkg builds are failing. Seems to be related to
   # problems with the libssl and libcrypto (OpenSSL libs) libs included in the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,17 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.xvfb
+    # x11vnc requires a shared IPC namespace with the X server it proxies
+    ipc: host
+  x11vnc:
+    build:
+      context: .
+      dockerfile: Dockerfile.x11vnc
+    ipc: host
+    environment:
+      DISPLAY: xvfb:0.0
+    depends_on:
+      - xvfb
 
   racket-x86:
     image: racket-x86

--- a/novnc-proxy.conf
+++ b/novnc-proxy.conf
@@ -1,0 +1,26 @@
+upstream websockify {
+    server websockify:50000;
+}
+
+server {
+    listen 80;
+    server_name localhost;
+
+    location /websockify {
+          proxy_http_version 1.1;
+          proxy_pass http://websockify/;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+
+          # VNC connection timeout
+          proxy_read_timeout 61s;
+
+          # Disable cache
+          proxy_buffering off;
+    }
+
+    location / {
+        root /usr/share/nginx/html;
+        index vnc.html;
+    }
+}

--- a/test-fail.sh
+++ b/test-fail.sh
@@ -17,3 +17,27 @@ racket -l tests/racket/embed-in-c
 racket -l tests/compiler/embed/test
 # fails with an error about #f being passed to `system*`
 racket -l distro-build/tests/unix-installer
+
+# GUI FAILURES
+
+# Fails due to font & rendering differences
+racket -l redex/tests/run-tests
+
+# mflatt
+# Fails due to suspected directory problems. Investigate why this needs
+# its own directory, possibly use explicit /tmpdir or edit test to avoid
+# directory dependency entirely.
+mkdir test-dir
+cd test-dir
+racket -l tests/gracket/test
+gracket -z -e 1
+gracket -e 1
+
+# TODO: Memory leak tests (in the tests/drracket/io/leak-on-run module)
+# causes script to hang, possibly because of Docker killing the module
+# execution process without the script properly catching the failure signal.
+# The run.sh script seems to only run modules and ought to be replaced by a
+# proper invocation of `raco test`.
+cd `raco fc tests/drracket/io`
+chmod +x run.sh
+bash ./run.sh

--- a/test-gui.sh
+++ b/test-gui.sh
@@ -5,41 +5,20 @@
 # one in its own Docker container that's shared for all tests.
 set -eufx
 
-# TODO: This script doesn't actually work yet. Commands that are known to fail
-# should be moved to the test-fail.sh script.
-
 # samth
-xvfb-run racket -l typed-racket-test -- --all
+racket -l typed-racket-test -- --all
 
 # jay
-xvfb-run raco test -c tests/xml # needs gui libs for XML snips
-xvfb-run raco test -c plai
+raco test -c tests/xml # needs gui libs for XML snips
+raco test -c plai
 
 # robby
-xvfb-run racket -l 2htdp/tests/bitmap-as-image-in-universe
-xvfb-run racket -l 2htdp/tests/image-equality-performance-htdp
-xvfb-run racket -l 2htdp/tests/image-equality-performance
-xvfb-run racket -l 2htdp/tests/image-too-large
-xvfb-run racket -l 2htdp/tests/test-image
+racket -l 2htdp/tests/bitmap-as-image-in-universe
+racket -l 2htdp/tests/image-equality-performance-htdp
+racket -l 2htdp/tests/image-equality-performance
+racket -l 2htdp/tests/image-too-large
+racket -l 2htdp/tests/test-image
 
-xvfb-run raco test -c framework/tests
+raco test -c framework/tests
 
-# fails due to font & rendering differences
-xvfb-run racket -l redex/tests/run-tests
-
-# mflatt
-# TODO: investigate why this needs its own directory, possibly use explicit
-# /tmpdir or edit test to avoid directory dependency entirely.
-mkdir test-dir
-cd test-dir
-xvfb-run racket -l tests/gracket/test
-xvfb-run gracket -z -e 1
-xvfb-run gracket -e 1
-
-cd `raco fc pcps-test`
-for i in *.rkt; do racket -t $i; done
-for i in *.ss; do racket -t $i; done
-
-cd `raco fc tests/drracket/io`
-chmod +x run.sh
-bash ./run.sh
+raco test -p pcps-test


### PR DESCRIPTION
To see the magic:

1. Run `docker-compose up -d nginx`
2. Run `docker-compose run racket-x86-test-gui`
3. Open `localhost` in your web browser
4. Click "connect"
5. Watch DrRacket open and close over and over, among other things

This works by using an external dockerized xvfb container that is shared by the GUI testing containers. An x11 to VNC proxy is hooked up to that xvfb container, then an instance of the [noVNC](https://github.com/novnc/noVNC) JS app is used to view the VNC proxy in a browser. As a neat bonus, it lets you watch every DrRacket startup screen easter egg!

TODO: Remove stale comments and update the README instructions.